### PR TITLE
Change how read and write defaults are accessed to allow multiple defaults

### DIFF
--- a/bin/cassandra_helper
+++ b/bin/cassandra_helper
@@ -2,7 +2,7 @@
 
 require 'rubygems'
 require 'rake'
-require 'cassandra'
+require 'twitter_cassandra'
 
 gem_path = $LOAD_PATH.last.sub(/lib$/, "")
 

--- a/lib/twitter_cassandra/mock.rb
+++ b/lib/twitter_cassandra/mock.rb
@@ -489,12 +489,14 @@ class TwitterCassandra
       output = OrderedHash.new
 
       columns.each do |column_name, value|
+        column_name = column_name.dup
         timestamp = columns.timestamps[column_name]
         column = column_class.new(column_name)
 
         if [Hash, OrderedHash].include?(value.class)
           output[column] ||= OrderedHash.new
           value.each do |sub_column, sub_column_value|
+            sub_column = sub_column.dup
             timestamp = value.timestamps[sub_column]
             output[column].[]=(sub_column_class.new(sub_column), sub_column_value, timestamp)
           end

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 require File.expand_path(File.dirname(__FILE__) + '/cassandra_test')
-require 'cassandra/mock'
+require 'twitter_cassandra/mock'
 require 'json'
 
 class CassandraMockTest < CassandraTest

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -50,12 +50,12 @@ class CassandraTest < Test::Unit::TestCase
     assert_nothing_raised do
       @twitter.default_read_consistency = TwitterCassandra::Consistency::ALL
     end
-    assert_equal(TwitterCassandra::READ_DEFAULTS[:consistency], TwitterCassandra::Consistency::ALL)
+    assert_equal(@twitter.read_defaults[:consistency], TwitterCassandra::Consistency::ALL)
 
     assert_nothing_raised do
       @twitter.default_write_consistency = TwitterCassandra::Consistency::ALL
     end
-    assert_equal(TwitterCassandra::WRITE_DEFAULTS[:consistency], TwitterCassandra::Consistency::ALL)
+    assert_equal(@twitter.write_defaults[:consistency], TwitterCassandra::Consistency::ALL)
   end
 
   def test_get_key

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 CASSANDRA_VERSION = ENV['CASSANDRA_VERSION'] || '0.8' unless defined?(CASSANDRA_VERSION)
 
 require 'test/unit'
-require "#{File.expand_path(File.dirname(__FILE__))}/../lib/cassandra/#{CASSANDRA_VERSION}"
+require "#{File.expand_path(File.dirname(__FILE__))}/../lib/twitter_cassandra/#{CASSANDRA_VERSION}"
 begin; require 'ruby-debug'; rescue LoadError; end
 
 begin


### PR DESCRIPTION
Currently this gem is organized such that read defaults and write defaults are stored as constants on the Cassanda class. These constants are accessed directly whenever those defaults are needed. This pattern makes it impossible to have one client use quorum reads and another client use a read consistency of 1 because both end up changing the same set of default options.

Even with subclassing, since constants are lexically scoped, it's impossible to override the default options such that two clients could have their own set of defaults.

This change restructures access to the defaults such that different client instances can have their own default read and write configuration.

I was unable to run tests for this repository, however the Backupify test suite is green following this change.
